### PR TITLE
Set NVIMGCODEC_EXTENSIONS_PATH on activate so runtime finds extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/activate-libnvimgcodec.sh
+++ b/recipe/activate-libnvimgcodec.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# nvImageCodec's runtime probes <so_dir>/../extensions, but this recipe
+# installs extensions to $PREFIX/lib/extensions, so the runtime never
+# finds them. Set NVIMGCODEC_EXTENSIONS_PATH to the install location.
+# Skip when the user has already exported a value so we don't clobber
+# their custom search path.
+if [ -z "${NVIMGCODEC_EXTENSIONS_PATH:-}" ]; then
+    export NVIMGCODEC_EXTENSIONS_PATH="${CONDA_PREFIX}/lib/extensions"
+    export _NVIMGCODEC_EXTENSIONS_PATH_SET_BY_CONDA=1
+fi

--- a/recipe/activate-libnvimgcodec.sh
+++ b/recipe/activate-libnvimgcodec.sh
@@ -2,9 +2,9 @@
 # nvImageCodec's runtime probes <so_dir>/../extensions, but this recipe
 # installs extensions to $PREFIX/lib/extensions, so the runtime never
 # finds them. Set NVIMGCODEC_EXTENSIONS_PATH to the install location.
-# Skip when the user has already exported a value so we don't clobber
-# their custom search path.
-if [ -z "${NVIMGCODEC_EXTENSIONS_PATH:-}" ]; then
+# Skip when the variable is already set — including to an empty string —
+# so an explicit user override (even "disable all extensions") wins.
+if [ -z "${NVIMGCODEC_EXTENSIONS_PATH+set}" ]; then
     export NVIMGCODEC_EXTENSIONS_PATH="${CONDA_PREFIX}/lib/extensions"
     export _NVIMGCODEC_EXTENSIONS_PATH_SET_BY_CONDA=1
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,3 +63,11 @@ rm $PREFIX/Acknowledgements.txt
 # Can also be overridden by env variable NVIMGCODEC_EXTENSIONS_PATH or in source code
 mv -v $PREFIX/extensions $PREFIX/lib/extensions
 sed -i 's|"${_PACKAGE_ROOTDIR}/extensions"|"${_PACKAGE_ROOTDIR}/lib/extensions"|g' $PREFIX/lib/cmake/nvimgcodec/nvimgcodecConfig.cmake
+
+# nvimgcodec <= 0.8 hard-codes its default plugin search path to <so_dir>/../extensions.
+# After the mv above, extensions live in $PREFIX/lib/extensions and the runtime can't find
+# them. Install activate/deactivate scripts that point NVIMGCODEC_EXTENSIONS_PATH at the
+# right directory whenever the env is active.
+mkdir -p $PREFIX/etc/conda/activate.d $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/activate-libnvimgcodec.sh   $PREFIX/etc/conda/activate.d/libnvimgcodec_activate.sh
+cp $RECIPE_DIR/deactivate-libnvimgcodec.sh $PREFIX/etc/conda/deactivate.d/libnvimgcodec_deactivate.sh

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -59,15 +59,17 @@ cmake --install . --strip
 rm $PREFIX/LICENSE.txt
 rm $PREFIX/Acknowledgements.txt
 
-# The default search path for nvimgcodec plugins is $PREFIX/lib/extensions
-# Can also be overridden by env variable NVIMGCODEC_EXTENSIONS_PATH or in source code
+# nvimgcodec <= 0.8 hard-codes its default plugin search path to <so_dir>/../extensions
+# (i.e. $PREFIX/extensions when the .so lives in $PREFIX/lib). That doesn't fit a
+# multi-output conda package well — extensions belong under lib/ alongside the .so so
+# they ride run_constrained subpackages — so we relocate them here, patch the CMake
+# config to match, and install activation scripts below to override the runtime search
+# path via NVIMGCODEC_EXTENSIONS_PATH.
 mv -v $PREFIX/extensions $PREFIX/lib/extensions
 sed -i 's|"${_PACKAGE_ROOTDIR}/extensions"|"${_PACKAGE_ROOTDIR}/lib/extensions"|g' $PREFIX/lib/cmake/nvimgcodec/nvimgcodecConfig.cmake
 
-# nvimgcodec <= 0.8 hard-codes its default plugin search path to <so_dir>/../extensions.
-# After the mv above, extensions live in $PREFIX/lib/extensions and the runtime can't find
-# them. Install activate/deactivate scripts that point NVIMGCODEC_EXTENSIONS_PATH at the
-# right directory whenever the env is active.
+# Install the activate/deactivate scripts that point NVIMGCODEC_EXTENSIONS_PATH at the
+# moved extensions directory whenever the env is active.
 mkdir -p $PREFIX/etc/conda/activate.d $PREFIX/etc/conda/deactivate.d
 cp $RECIPE_DIR/activate-libnvimgcodec.sh   $PREFIX/etc/conda/activate.d/libnvimgcodec_activate.sh
 cp $RECIPE_DIR/deactivate-libnvimgcodec.sh $PREFIX/etc/conda/deactivate.d/libnvimgcodec_deactivate.sh

--- a/recipe/deactivate-libnvimgcodec.sh
+++ b/recipe/deactivate-libnvimgcodec.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Counterpart to activate-libnvimgcodec.sh: only unset the env var if we
+# set it ourselves, so a user's pre-existing NVIMGCODEC_EXTENSIONS_PATH
+# survives an activate/deactivate cycle.
+if [ -n "${_NVIMGCODEC_EXTENSIONS_PATH_SET_BY_CONDA:-}" ]; then
+    unset NVIMGCODEC_EXTENSIONS_PATH
+    unset _NVIMGCODEC_EXTENSIONS_PATH_SET_BY_CONDA
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - patches/0004-BLD-Disable-non-standard-CUDA-arch-checking.patch
     - patches/0005-BUG-Skip-runtime-nvtiff-check-when-linking-at-build-.patch
 build:
-  number: 1
+  number: 2
   skip: true  # [((cuda_compiler_version or "None") == "None")]
   # skip: true  # [((cuda_compiler_version or "") == "12.6") and ((libopencv or "") == "4.10") ]
 requirements:
@@ -89,6 +89,7 @@ outputs:
         - lib/python*  # [linux]
         - lib/libnvimgcodec.so.*  # [linux]
         - lib/extensions/*.so.*  # [linux]
+        - etc/conda/**  # [linux]
     requirements:
       host:
         - {{ pin_subpackage('libnvimgcodec' ~ somajor, exact=True) }}
@@ -148,6 +149,8 @@ outputs:
       include:
         - lib/libnvimgcodec.so.*  # [linux]
         - lib/extensions/*.so.*  # [linux]
+        - etc/conda/activate.d/libnvimgcodec_activate.sh  # [linux]
+        - etc/conda/deactivate.d/libnvimgcodec_deactivate.sh  # [linux]
         - Library/bin/nvimgcodec_{{ somajor }}.dll  # [win]
         - Library/extensions/*.dll  # [win]
       exclude:
@@ -193,6 +196,8 @@ outputs:
       commands:
         - test -f ${PREFIX}/lib/libnvimgcodec.so.{{ somajor }}  # [linux]
         - test -f ${PREFIX}/lib/libnvimgcodec.so.{{ version }}  # [linux]
+        - test -f ${PREFIX}/etc/conda/activate.d/libnvimgcodec_activate.sh  # [linux]
+        - test -f ${PREFIX}/etc/conda/deactivate.d/libnvimgcodec_deactivate.sh  # [linux]
         - test -f ${PREFIX}/lib/extensions/libnvbmp_ext.so.{{ version }}  # [linux]
         - test -f ${PREFIX}/lib/extensions/libnvjpeg_ext.so.{{ version }}  # [linux]
         - test -f ${PREFIX}/lib/extensions/libnvjpeg2k_ext.so.{{ version }}  # [linux]


### PR DESCRIPTION
## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged) — 1 → 2
- [x] Re-rendered with the latest conda-smithy
- [x] Ensured the license file is being packaged
- [x] PR title is descriptive and meaningful

## What this fixes

A conda-forge install of `libnvimgcodec` (0.8.0) loads but exposes no decoders or encoders — every codec silently fails `canDecode` / `canEncode`.

The recipe moves extensions to `$PREFIX/lib/extensions` (see `recipe/build.sh`), but the nvimgcodec 0.8 runtime probes `<so_dir>/../extensions`, i.e. `$CONDA_PREFIX/extensions`. The two paths don't agree, so the runtime never finds the extension shared objects.

A future nvimgcodec release will probe both candidates from `GetDefaultExtensionsPath()` directly and won't need this bridge. For 0.8 that fix is not in the `.so`, so this PR ships matching activate/deactivate scripts instead.

## How

- Add `recipe/activate-libnvimgcodec.sh` and `recipe/deactivate-libnvimgcodec.sh`. The activate script sets `NVIMGCODEC_EXTENSIONS_PATH=$CONDA_PREFIX/lib/extensions` only when the user hasn't already exported a value, so a custom search path survives unchanged. The deactivate script unsets the variable only when we set it ourselves, marked via `_NVIMGCODEC_EXTENSIONS_PATH_SET_BY_CONDA`.
- `recipe/build.sh`: install the two scripts under `$PREFIX/etc/conda/{activate,deactivate}.d/`.
- `recipe/meta.yaml`:
    - `libnvimgcodec-dev` excludes `etc/conda/**` so its broad `etc/**` glob doesn't pull the activation scripts into the dev package.
    - `libnvimgcodec0` (the runtime output) explicitly includes the two scripts and adds `test -f` checks for them.
    - `build.number: 1` → `2` so conda-forge publishes the rebuild.

Linux-only — Windows installs to `Library/extensions/`, which the existing runtime resolution already finds correctly.
